### PR TITLE
Support to drop callback (jquery.jOrgChart.js)

### DIFF
--- a/js/jquery.jOrgChart.js
+++ b/js/jquery.jOrgChart.js
@@ -160,6 +160,14 @@
           targetLi.append("<ul></ul>");
           targetLi.children('ul').append(sourceLi);
         }
+        
+        // Check if the dragAndDrop option is a callback
+        if (typeof opts.dragAndDrop == 'function') {
+            // Need the original li id's
+            var source = $(sourceLi).attr('id');
+            var target = $(targetLi).attr('id');
+            opts.dragAndDrop.call(this,source,target);
+        }
 
       }); // handleDropEvent
 


### PR DESCRIPTION
As we speak, here is the inclusion of support for callback functions on the event drop as user review @deJong-IT in https://github.com/wesnolte/jOrgChart/issues/25#issuecomment-11480187. I hope it's satisfactory. In resume, if option dragAndDrop is set a function, the callback runs.
Note: In use, the solution worked well. But I noticed a certain delay between the drop event and the redraw of the chart, so I was forced to use a temporary timeout in my handler function, until find a better solution.
I take this opportunity to thank you for consideration and commend his excellent work with the script. Congratulations!
